### PR TITLE
IssueId #216634 feat While highlighting - text need not be made red, …

### DIFF
--- a/src/views/Practice/Practice.jsx
+++ b/src/views/Practice/Practice.jsx
@@ -570,8 +570,7 @@ const Practice = () => {
                 <Typography
                   variant="h5"
                   component="h4"
-                  sx={{
-                    color: "#FF4830",
+                  sx={{                  
                     fontSize: `${fontSize}px`,
                     lineHeight: "normal",
                     fontWeight: 700,
@@ -624,7 +623,6 @@ const Practice = () => {
                 component="h4"
                 ml={1}
                 sx={{
-                  color: "#FF4830",
                   fontSize: `${fontSize}px`,
                   lineHeight: "normal",
                   fontWeight: 700,


### PR DESCRIPTION
…keep it black in [Storylingo V2]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Removed specific color settings from text in the Practice view for a more uniform appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->