### PR TITLE
IssueId #0000 fix: disabled next button if user not speak

### DIFF
--- a/src/utils/AudioCompare.js
+++ b/src/utils/AudioCompare.js
@@ -60,7 +60,9 @@ const AudioRecorderCompair = (props) => {
           message: "Please Speak Louder and Clear",
           isError: true,
         });
-        props.setEnableNext(false);
+        if (props.setEnableNext) {
+          props.setEnableNext(false);
+        }
       }
       setRecordingInitialized(false);
       props.setRecordedAudio(temp_audioSrc);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced stability by ensuring the `setEnableNext` function is called only if it exists, preventing potential errors during audio comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->