### PR TITLE
Bug #221383 fix: speak again popup is not showing properly.

### DIFF
--- a/src/views/Practice/Practice.jsx
+++ b/src/views/Practice/Practice.jsx
@@ -111,7 +111,11 @@ const Practice = () => {
 
   useEffect(() => {
     if (voiceText === "error") {
-      alert("Sorry I couldn't hear a voice. Could you please speak again?");
+      setOpenMessageDialog({
+        message: "Sorry I couldn't hear a voice. Could you please speak again?",
+        isError: true,
+      });
+      // alert("Sorry I couldn't hear a voice. Could you please speak again?");
       setVoiceText("");
       setEnableNext(false);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated error messaging in the Practice component to use a dialog box instead of an alert, providing a more visually appealing user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->